### PR TITLE
fix: resolve u32/usize type mismatches in Unix ancillary message handling

### DIFF
--- a/src/net/unix/stream.rs
+++ b/src/net/unix/stream.rs
@@ -766,7 +766,7 @@ fn recv_with_ancillary_impl(
         // SAFETY: recvmsg has written msg_controllen bytes of valid
         // control message data to the buffer.
         unsafe {
-            ancillary.set_len(msg.msg_controllen, truncated);
+            ancillary.set_len(msg.msg_controllen as usize, truncated);
         }
         let len = usize::try_from(ret).unwrap_or(0);
         Ok(len)

--- a/src/runtime/reactor/mod.rs
+++ b/src/runtime/reactor/mod.rs
@@ -586,11 +586,13 @@ pub fn create_reactor() -> io::Result<Arc<dyn Reactor>> {
     target_os = "netbsd",
     target_os = "dragonfly"
 ))]
+/// Create a reactor for POSIX systems using kqueue.
 pub fn create_reactor() -> io::Result<Arc<dyn Reactor>> {
     Ok(Arc::new(KqueueReactor::new()?))
 }
 
 #[cfg(target_os = "windows")]
+/// Create a reactor for Windows systems using mio.
 pub fn create_reactor() -> io::Result<Arc<dyn Reactor>> {
     Ok(Arc::new(IocpReactor::new()?))
 }


### PR DESCRIPTION
## Summary

Fixes compilation errors when building with Rust 2024 edition where `mem::size_of::<T>()` returns `usize` but `cmsg_len` and `msg_controllen` are `socklen_t` (u32 on POSIX systems).

## Changes

### src/net/unix/ancillary.rs
- Convert `size_of` results to `u32` for comparison with `cmsg_len`
- Cast `fd_count` calculation to proper `usize` type for slice creation

### src/net/unix/stream.rs
- Cast `msg.msg_controllen` from `u32` to `usize` when calling `set_len()`

### src/runtime/reactor/mod.rs
- Add missing doc comments for `create_reactor()` functions

## Motivation

When building the asupersync crate with Rust 2024 edition, the compiler reports type mismatch errors because:
- `cmsg_len` from `libc::cmsghdr` is `u32`
- `mem::size_of::<T>()` returns `usize`
- Direct comparison/subtraction between these types fails

These fixes ensure type consistency when comparing/operating on `cmsg_len` (u32) with `mem::size_of::<T>()` (usize) results.