### PR TITLE
Fix x86_64 build (E0133): wrap __cpuid in an unsafe block

### DIFF
--- a/src/atp/timing_security.rs
+++ b/src/atp/timing_security.rs
@@ -148,8 +148,12 @@ fn cpuid_tsc_frequency_hz(max_basic_leaf: u32) -> Option<u64> {
 }
 
 #[cfg(target_arch = "x86_64")]
+#[allow(unsafe_code)]
 fn cpuid(leaf: u32) -> core::arch::x86_64::CpuidResult {
-    core::arch::x86_64::__cpuid(leaf)
+    // SAFETY: `__cpuid` issues the CPUID instruction, which is unconditionally
+    // available on x86_64 and performs no memory access; it is `unsafe` only as a
+    // raw arch intrinsic. Mirrors the discipline in `read_tsc_ordered` below.
+    unsafe { core::arch::x86_64::__cpuid(leaf) }
 }
 
 #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
 ### Summary
  `asupersync` fails to compile on **x86_64** — `cargo build` errors with
  `E0133` in
  `src/atp/timing_security.rs`. The one-line `cpuid()` helper calls the
  `__cpuid`
  intrinsic outside an `unsafe` block. This wraps it, mirroring the existing
  `read_tsc_ordered` helper just below.

  ### Reproduce
  On any x86_64 host: `cargo build` →
  error[E0133]: call to unsafe function core::arch::x86_64::__cpuid is
  unsafe
                and requires unsafe function or block
     --> src/atp/timing_security.rs:152:5

  ### Root cause
  `cpuid()` is `#[cfg(target_arch = "x86_64")]`-gated and calls the `unsafe`
  intrinsic
  `__cpuid` directly, while the crate is `#![deny(unsafe_code)]`. On
  **aarch64**
  (e.g. Apple Silicon / macOS CI) the `cfg(not(...))` stub at line 122 is
  compiled
  instead, so this function is never built — likely why it shipped. The
  sibling
  `read_tsc_ordered` already uses the correct `#[allow(unsafe_code)]` +
  `unsafe { … }`
  + `// SAFETY:` pattern; `cpuid` just missed it.

  ### Note
  Consider adding an x86_64 job to CI — this class of
  `#[cfg(target_arch)]`-gated
  breakage is invisible on an aarch64-only matrix. Thanks for the crate. 🦀
